### PR TITLE
DNS fixes (alias support and rh/ubuntu fixes) + Role by state configuration [13/26]

### DIFF
--- a/chef/data_bags/crowbar/bc-template-hive.json
+++ b/chef/data_bags/crowbar/bc-template-hive.json
@@ -26,6 +26,9 @@
   "deployment": {
     "hive": {
       "crowbar-revision": 0,
+      "element_states": {
+        "hive-interpreter": [ "readying", "ready", "applying" ]
+      },
       "elements": {},
       "element_order": [
         [

--- a/chef/data_bags/crowbar/bc-template-hive.schema
+++ b/chef/data_bags/crowbar/bc-template-hive.schema
@@ -45,6 +45,16 @@
             "crowbar-revision": { "type": "int", "required": true },
             "crowbar-committing": { "type": "bool" },
             "crowbar-queued": { "type": "bool" },
+            "element_states": {
+              "type": "map",
+              "mapping": {
+                = : {
+                  "type": "seq",
+                  "required": true,
+                  "sequence": [ { "type": "str" } ]
+                }
+              }
+            },
             "elements": {
               "type": "map",
               "required": true,


### PR DESCRIPTION
This allows for the DNS barclamp to work correctly in ubuntu and redhat.

Update the barclamps to have element_states for mapping their roles to states for when to execute.

 chef/data_bags/crowbar/bc-template-hive.json   |    3 +++
 chef/data_bags/crowbar/bc-template-hive.schema |   10 ++++++++++
 2 files changed, 13 insertions(+), 0 deletions(-)
