### PR TITLE
Move the crowbar.yml layout to v2 [11/27]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -25,7 +25,7 @@ barclamp:
     - apachehadoop
 
 crowbar:
-  layout: 1
+  layout: 2
   order: 400
   run_order: 400
   chef_order: 400

--- a/crowbar_framework/doc/default/hive/barclamp-info.md
+++ b/crowbar_framework/doc/default/hive/barclamp-info.md
@@ -1,0 +1,5 @@
+### Hive Barclamp
+
+This barclamp does... 
+
+

--- a/crowbar_framework/doc/default/hive/licenses.md
+++ b/crowbar_framework/doc/default/hive/licenses.md
@@ -1,0 +1,10 @@
+### Hive Barclamp Licenses
+
+This file contains information (if updated by the barclamp authors!) about the licenses that apply to your installation.
+
+The following dependencies are required:
+
+* ?
+
+
+

--- a/crowbar_framework/doc/hive.yml
+++ b/crowbar_framework/doc/hive.yml
@@ -1,0 +1,12 @@
+# theses are the default meta_data values
+license:    Apache 2
+copyright:  2012 by Dell, Inc
+date:       July 25, 2012
+
+crowbar+book-barclamps:
+  apachehadoop+meta
+    hive+barclamp-info
+    
+crowbar+book-licenses:
+  apachehadoop+licenses-meta:
+    hive+licenses


### PR DESCRIPTION
Recent changes to add the database required us to update
the layout version.

I also added a doc skeleton while I was touching everything

 crowbar.yml                                        |    2 +-
 .../doc/default/hive/barclamp-info.md              |    5 +++++
 crowbar_framework/doc/default/hive/licenses.md     |   10 ++++++++++
 crowbar_framework/doc/hive.yml                     |   12 ++++++++++++
 4 files changed, 28 insertions(+), 1 deletions(-)
