### PR TITLE
Fixed hive server startup - rpm packaging has changed for the CDH4 distribution [1/1]

### DIFF
--- a/chef/cookbooks/hive/recipes/default.rb
+++ b/chef/cookbooks/hive/recipes/default.rb
@@ -16,20 +16,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Author: Paul Webster
-#
 
 #######################################################################
-# Begin recipe transactions
+# Begin recipe
 #######################################################################
 debug = node[:hive][:debug]
 Chef::Log.info("BEGIN hive") if debug
 
-package "hive" do
-  action :install
+hive_packages=%w{
+  hive
+  hive-metastore
+  hive-server
+  hive-server2
+}
+
+hive_packages.each do |pkg|
+  package pkg do
+    action :install
+  end
 end
 
-service "hiveserver" do
+service "hive-server" do
   supports :start => true, :stop => true, :status => true, :restart => true
   action :enable
 end
@@ -40,14 +47,14 @@ template "/etc/hive/conf/hive-site.xml" do
   group node[:hive][:global_file_system_group]
   mode "0644"
   source "hive-site.xml.erb"
-  notifies :restart, resources(:service => "hiveserver")
+  notifies :restart, resources(:service => "hive-server")
 end
 
-service "hiveserver" do
+service "hive-server" do
   action  :start
 end
 
 #######################################################################
-# End of recipe transactions
+# End of recipe
 #######################################################################
 Chef::Log.info("END hive") if debug

--- a/chef/data_bags/crowbar/bc-template-hive.json
+++ b/chef/data_bags/crowbar/bc-template-hive.json
@@ -3,7 +3,7 @@
   "description": "Data warehouse infrastructure that provides SQL based data summarization and ad hoc querying.",
   "attributes": {
     "hive": {
-      "debug": true,
+      "debug": false,
 	  "admin_ip_eval": "Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, \"admin\").address",
       "admin_interface_eval": "Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, \"admin\").interface",
       "hive_default_fileformat": "TextFile",

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -36,6 +36,9 @@ locale_additions:
       hive:
         edit_attributes:
           attributes: Attributes
+          barclamp_settings: Barclamp
+          debug: Log Debug Messages
+          hive_settings: Hive
           hive_default_fileformat: Default File Format
           hive_exec_compress_intermediate: Execution Compress Intermediate
           hive_exec_compress_output: Execution Compress Output

--- a/crowbar_framework/app/views/barclamp/hive/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/hive/_edit_attributes.html.haml
@@ -4,6 +4,18 @@
   %label{:for => "proposal_attributes"}= t('.attributes')
   = link_to "Raw", proposal_barclamp_path(:id => @proposal.name, :controller => @proposal.barclamp, :dep_raw => @dep_raw, :attr_raw => true), :style => "float: right;"
   %div.container
+ 
+    %p
+    %br
+    %strong= t('.barclamp_settings')
+
+    %p
+      %label{ :for => :debug }= t('.debug')
+      = select_tag :debug, options_for_select([['false', false],['true', true]], @proposal.raw_data['attributes'][@proposal.barclamp]["debug"]), :onchange => "update_value('debug', 'debug', 'boolean')"
+
+    %p
+    %br
+    %strong= t('.hive_settings')
 
     %p
       %label{ :for => :hive_default_fileformat }= t('.hive_default_fileformat')


### PR DESCRIPTION
Fixed hive server startup - rpm packaging has changed for the CDH4 distribution.
Added debug toggle control on the crowbar UI so the user can toggle it on or off without having to edit the json control file.

 chef/cookbooks/hive/recipes/default.rb             |   25 ++++++++++++-------
 chef/data_bags/crowbar/bc-template-hive.json       |    2 +-
 crowbar.yml                                        |    3 ++
 .../views/barclamp/hive/_edit_attributes.html.haml |   12 +++++++++
 4 files changed, 32 insertions(+), 10 deletions(-)

Crowbar-Pull-ID: 9685d32c4dc1e84e533b37f11a2527c22cc79282

Crowbar-Release: fred
